### PR TITLE
envoy attempt to match istio wildcard port listener

### DIFF
--- a/bazel/foreign_cc/luajit.patch
+++ b/bazel/foreign_cc/luajit.patch
@@ -65,8 +65,8 @@ index 0000000..9c71271
 +
 +    os.environ["MACOSX_DEPLOYMENT_TARGET"] = "10.6"
 +    os.environ["DEFAULT_CC"] = os.environ.get("CC", "")
-+    os.environ["TARGET_CFLAGS"] = os.environ.get("CFLAGS", "")
-+    os.environ["TARGET_LDFLAGS"] = os.environ.get("CFLAGS", "")
++    os.environ["TARGET_CFLAGS"] = os.environ.get("CFLAGS", "") + " -fno-function-sections -fno-data-sections"
++    os.environ["TARGET_LDFLAGS"] = os.environ.get("CFLAGS", "") + " -fno-function-sections -fno-data-sections"
 +    os.environ["CFLAGS"] = ""
 +    # LuaJIT compile process build a tool `buildvm` and use it, building `buildvm` with ASAN
 +    # will cause LSAN detect its leak and fail the build, set exitcode to 0 to make LSAN doesn't

--- a/docs/root/configuration/http_filters/lua_filter.rst
+++ b/docs/root/configuration/http_filters/lua_filter.rst
@@ -312,6 +312,32 @@ Returns the current request's underlying :repo:`connection <include/envoy/networ
 
 Returns a :ref:`connection object <config_http_filters_lua_connection_wrapper>`.
 
+importPublicKey()
+^^^^^^^^^^^^^^^^^
+
+.. code-block:: lua
+  
+  pubkey = handle:importPublicKey(keyder, keyderLength)
+
+Returns public key which is used by :ref:`verifySignature <verify_signature>` to verify digital signature. 
+
+.. _verify_signature:
+
+verifySignature()
+^^^^^^^^^^^^^^^^^
+
+.. code-block:: lua
+
+  ok, error = verifySignature(hashFunction, pubkey, signature, signatureLength, data, dataLength)
+
+Verify signature using provided parameters. *hashFunction* is the variable for hash function which be used 
+for verifying signature. *SHA1*, *SHA224*, *SHA256*, *SHA384* and *SHA512* are supported. 
+*pubkey* is the public key. *signature* is the signature to be verified. *signatureLength* is 
+the length of the signature. *data* is the content which will be hashed. *dataLength* is the length of data.
+
+The function returns a pair. If the first element is *true*, the second element will be empty
+which means signature is verified; otherwise, the second element will store the error message. 
+
 .. _config_http_filters_lua_header_wrapper:
 
 Header object API

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -21,6 +21,12 @@ Version history
 * http: fixed a crashing bug where gRPC local replies would cause segfaults when upstream access logging was on.
 * http: mitigated a race condition with the :ref:`delayed_close_timeout<envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.delayed_close_timeout>` where it could trigger while actively flushing a pending write buffer for a downstream connection.
 * jwt_authn: make filter's parsing of JWT more flexible, allowing syntax like ``jwt=eyJhbGciOiJS...ZFnFIw,extra=7,realm=123``
+* listener: added :ref:`source IP <envoy_api_field_listener.FilterChainMatch.source_prefix_ranges>`
+  and :ref:`source port <envoy_api_field_listener.FilterChainMatch.source_ports>` filter
+  chain matching.
+* lua: exposed functions to Lua to verify digital signature.
+* original_src filter: added the :ref:`filter<config_http_filters_original_src>`.
+* rbac: migrated from v2alpha to v2.
 * redis: add support for Redis cluster custom cluster type.
 * redis: added :ref:`prefix routing <envoy_api_field_config.filter.network.redis_proxy.v2.RedisProxy.prefix_routes>` to enable routing commands based on their key's prefix to different upstream.
 * redis: add support for zpopmax and zpopmin commands.

--- a/source/common/crypto/utility.cc
+++ b/source/common/crypto/utility.cc
@@ -3,7 +3,9 @@
 #include "common/common/assert.h"
 #include "common/common/stack_array.h"
 
-#include "openssl/evp.h"
+#include "absl/strings/ascii.h"
+#include "absl/strings/str_cat.h"
+#include "openssl/bytestring.h"
 #include "openssl/hmac.h"
 #include "openssl/sha.h"
 
@@ -39,6 +41,61 @@ std::vector<uint8_t> Utility::getSha256Hmac(const std::vector<uint8_t>& key,
            message.size(), hmac.data(), &len);
   RELEASE_ASSERT(ret != nullptr, "Failed to create HMAC");
   return hmac;
+}
+
+const VerificationOutput Utility::verifySignature(absl::string_view hash, EVP_PKEY* pubKey,
+                                                  const std::vector<uint8_t>& signature,
+                                                  const std::vector<uint8_t>& text) {
+  // Step 1: initialize EVP_MD_CTX
+  bssl::ScopedEVP_MD_CTX ctx;
+
+  // Step 2: initialize EVP_MD
+  const EVP_MD* md = Utility::getHashFunction(hash);
+
+  if (md == nullptr) {
+    return {false, absl::StrCat(hash, " is not supported.")};
+  }
+
+  // Step 3: initialize EVP_DigestVerify
+  int ok = EVP_DigestVerifyInit(ctx.get(), nullptr, md, nullptr, pubKey);
+  if (!ok) {
+    return {false, "Failed to initialize digest verify."};
+  }
+
+  // Step 4: verify signature
+  ok = EVP_DigestVerify(ctx.get(), signature.data(), signature.size(), text.data(), text.size());
+
+  // Step 5: check result
+  if (ok == 1) {
+    return {true, ""};
+  }
+
+  return {false, absl::StrCat("Failed to verify digest. Error code: ", ok)};
+}
+
+PublicKeyPtr Utility::importPublicKey(const std::vector<uint8_t>& key) {
+  CBS cbs({key.data(), key.size()});
+  return PublicKeyPtr(EVP_parse_public_key(&cbs));
+}
+
+const EVP_MD* Utility::getHashFunction(absl::string_view name) {
+  const std::string hash = absl::AsciiStrToLower(name);
+
+  // Hash algorithms set refers
+  // https://github.com/google/boringssl/blob/master/include/openssl/digest.h
+  if (hash == "sha1") {
+    return EVP_sha1();
+  } else if (hash == "sha224") {
+    return EVP_sha224();
+  } else if (hash == "sha256") {
+    return EVP_sha256();
+  } else if (hash == "sha384") {
+    return EVP_sha384();
+  } else if (hash == "sha512") {
+    return EVP_sha512();
+  } else {
+    return nullptr;
+  }
 }
 
 } // namespace Crypto

--- a/source/common/crypto/utility.h
+++ b/source/common/crypto/utility.h
@@ -6,10 +6,26 @@
 #include "envoy/buffer/buffer.h"
 
 #include "absl/strings/string_view.h"
+#include "openssl/evp.h"
 
 namespace Envoy {
 namespace Common {
 namespace Crypto {
+
+struct VerificationOutput {
+  /**
+   * Verification result. If result_ is true, error_message_ is empty.
+   */
+  bool result_;
+
+  /**
+   * Error message when verification failed.
+   * TODO(crazyxy): switch to absl::StatusOr when available
+   */
+  std::string error_message_;
+};
+
+typedef bssl::UniquePtr<EVP_PKEY> PublicKeyPtr;
 
 class Utility {
 public:
@@ -28,6 +44,29 @@ public:
    */
   static std::vector<uint8_t> getSha256Hmac(const std::vector<uint8_t>& key,
                                             absl::string_view message);
+
+  /**
+   * Verify cryptographic signatures.
+   * @param hash hash function(including SHA1, SHA224, SHA256, SHA384, SHA512)
+   * @param key pointer to public key
+   * @param signature signature
+   * @param text clear text
+   * @return If the result_ is true, the error_message_ is empty; otherwise,
+   * the error_message_ stores the error message
+   */
+  static const VerificationOutput verifySignature(absl::string_view hash, EVP_PKEY* key,
+                                                  const std::vector<uint8_t>& signature,
+                                                  const std::vector<uint8_t>& text);
+
+  /**
+   * Import public key.
+   * @param key key string
+   * @return pointer to public key
+   */
+  static PublicKeyPtr importPublicKey(const std::vector<uint8_t>& key);
+
+private:
+  static const EVP_MD* getHashFunction(absl::string_view name);
 };
 
 } // namespace Crypto

--- a/source/common/http/codec_client.h
+++ b/source/common/http/codec_client.h
@@ -79,6 +79,11 @@ public:
   uint64_t id() { return connection_->id(); }
 
   /**
+   * @return the underlying codec protocol.
+   */
+  Protocol protocol() { return codec_->protocol(); }
+
+  /**
    * @return the underlying connection error.
    */
   absl::string_view connectionFailureReason() { return connection_->transportFailureReason(); }

--- a/source/common/http/http1/conn_pool.h
+++ b/source/common/http/http1/conn_pool.h
@@ -73,7 +73,7 @@ protected:
 
     ActiveClient& parent_;
     bool encode_complete_{};
-    bool saw_close_header_{};
+    bool close_connection_{};
     bool decode_complete_{};
   };
 

--- a/source/common/network/utility.h
+++ b/source/common/network/utility.h
@@ -140,6 +140,12 @@ public:
   static bool isLocalConnection(const Network::ConnectionSocket& socket);
 
   /**
+   * Determine whether this is a local address.
+   * @return bool the address is a local address.
+   */
+  static bool isLocalIpAddress(const Address::Instance& address);
+
+  /**
    * Determine whether this is an internal (RFC1918) address.
    * @return bool the address is an RFC1918 address.
    */

--- a/source/extensions/filters/http/lua/BUILD
+++ b/source/extensions/filters/http/lua/BUILD
@@ -22,6 +22,7 @@ envoy_cc_library(
         "//include/envoy/upstream:cluster_manager_interface",
         "//source/common/buffer:buffer_lib",
         "//source/common/common:enum_to_int",
+        "//source/common/crypto:utility_lib",
         "//source/common/http:message_lib",
         "//source/extensions/filters/common/lua:lua_lib",
         "//source/extensions/filters/common/lua:wrappers_lib",
@@ -36,6 +37,7 @@ envoy_cc_library(
     deps = [
         "//include/envoy/http:header_map_interface",
         "//include/envoy/stream_info:stream_info_interface",
+        "//source/common/crypto:utility_lib",
         "//source/common/http:utility_lib",
         "//source/extensions/filters/common/lua:lua_lib",
         "//source/extensions/filters/common/lua:wrappers_lib",

--- a/source/extensions/filters/http/lua/lua_filter.h
+++ b/source/extensions/filters/http/lua/lua_filter.h
@@ -127,14 +127,23 @@ public:
   }
 
   static ExportedFunctions exportedFunctions() {
-    return {{"headers", static_luaHeaders},         {"body", static_luaBody},
-            {"bodyChunks", static_luaBodyChunks},   {"trailers", static_luaTrailers},
-            {"metadata", static_luaMetadata},       {"logTrace", static_luaLogTrace},
-            {"logDebug", static_luaLogDebug},       {"logInfo", static_luaLogInfo},
-            {"logWarn", static_luaLogWarn},         {"logErr", static_luaLogErr},
-            {"logCritical", static_luaLogCritical}, {"httpCall", static_luaHttpCall},
-            {"respond", static_luaRespond},         {"streamInfo", static_luaStreamInfo},
-            {"connection", static_luaConnection}};
+    return {{"headers", static_luaHeaders},
+            {"body", static_luaBody},
+            {"bodyChunks", static_luaBodyChunks},
+            {"trailers", static_luaTrailers},
+            {"metadata", static_luaMetadata},
+            {"logTrace", static_luaLogTrace},
+            {"logDebug", static_luaLogDebug},
+            {"logInfo", static_luaLogInfo},
+            {"logWarn", static_luaLogWarn},
+            {"logErr", static_luaLogErr},
+            {"logCritical", static_luaLogCritical},
+            {"httpCall", static_luaHttpCall},
+            {"respond", static_luaRespond},
+            {"streamInfo", static_luaStreamInfo},
+            {"connection", static_luaConnection},
+            {"importPublicKey", static_luaImportPublicKey},
+            {"verifySignature", static_luaVerifySignature}};
   }
 
 private:
@@ -210,6 +219,27 @@ private:
   DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaLogCritical);
 
   /**
+   * Verify cryptographic signatures.
+   * @param 1 (string) hash function(including SHA1, SHA224, SHA256, SHA384, SHA512)
+   * @param 2 (void*)  pointer to public key
+   * @param 3 (string) signature
+   * @param 4 (int)    length of signature
+   * @param 5 (string) clear text
+   * @param 6 (int)    length of clear text
+   * @return (bool, string) If the first element is true, the second element is empty; otherwise,
+   * the second element stores the error message
+   */
+  DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaVerifySignature);
+
+  /**
+   * Import public key.
+   * @param 1 (string) keyder string
+   * @param 2 (int)    length of keyder string
+   * @return pointer to public key
+   */
+  DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaImportPublicKey);
+
+  /**
    * This is the closure/iterator returned by luaBodyChunks() above.
    */
   DECLARE_LUA_CLOSURE(StreamHandleWrapper, luaBodyIterator);
@@ -226,6 +256,7 @@ private:
     metadata_wrapper_.reset();
     stream_info_wrapper_.reset();
     connection_wrapper_.reset();
+    public_key_wrapper_.reset();
   }
 
   // Http::AsyncClient::Callbacks
@@ -247,6 +278,7 @@ private:
   Filters::Common::Lua::LuaDeathRef<Filters::Common::Lua::MetadataMapWrapper> metadata_wrapper_;
   Filters::Common::Lua::LuaDeathRef<StreamInfoWrapper> stream_info_wrapper_;
   Filters::Common::Lua::LuaDeathRef<Filters::Common::Lua::ConnectionWrapper> connection_wrapper_;
+  Filters::Common::Lua::LuaDeathRef<PublicKeyWrapper> public_key_wrapper_;
   State state_{State::Running};
   std::function<void()> yield_callback_;
   Http::AsyncClient::Request* http_request_{};

--- a/source/extensions/filters/http/lua/wrappers.cc
+++ b/source/extensions/filters/http/lua/wrappers.cc
@@ -174,6 +174,15 @@ int DynamicMetadataMapWrapper::luaPairs(lua_State* state) {
   return 1;
 }
 
+int PublicKeyWrapper::luaGet(lua_State* state) {
+  if (public_key_ == nullptr || public_key_.get() == nullptr) {
+    lua_pushnil(state);
+  } else {
+    lua_pushlightuserdata(state, public_key_.get());
+  }
+  return 1;
+}
+
 } // namespace Lua
 } // namespace HttpFilters
 } // namespace Extensions

--- a/source/extensions/filters/http/lua/wrappers.h
+++ b/source/extensions/filters/http/lua/wrappers.h
@@ -3,6 +3,8 @@
 #include "envoy/http/header_map.h"
 #include "envoy/stream_info/stream_info.h"
 
+#include "common/crypto/utility.h"
+
 #include "extensions/filters/common/lua/lua.h"
 
 namespace Envoy {
@@ -199,6 +201,24 @@ private:
   Filters::Common::Lua::LuaDeathRef<DynamicMetadataMapWrapper> dynamic_metadata_wrapper_;
 
   friend class DynamicMetadataMapWrapper;
+};
+
+/**
+ * Lua wrapper for EVP_PKEY.
+ */
+class PublicKeyWrapper : public Filters::Common::Lua::BaseLuaObject<PublicKeyWrapper> {
+public:
+  PublicKeyWrapper(Envoy::Common::Crypto::PublicKeyPtr key) : public_key_(std::move(key)) {}
+  static ExportedFunctions exportedFunctions() { return {{"get", static_luaGet}}; }
+
+private:
+  /**
+   * Get a pointer to public key.
+   * @return pointer to public key.
+   */
+  DECLARE_LUA_FUNCTION(PublicKeyWrapper, luaGet);
+
+  Envoy::Common::Crypto::PublicKeyPtr public_key_;
 };
 
 } // namespace Lua

--- a/test/common/crypto/utility_test.cc
+++ b/test/common/crypto/utility_test.cc
@@ -50,6 +50,73 @@ TEST(UtilityTest, TestSha256HmacWithEmptyArguments) {
   EXPECT_EQ("b613679a0814d9ec772f95d778c35fc5ff1697c493715653c6c712144292c5ad", Hex::encode(hmac));
 }
 
+TEST(UtilityTest, TestImportPublicKey) {
+  auto key = "30820122300d06092a864886f70d01010105000382010f003082010a0282010100a7471266d01d160308d"
+             "73409c06f2e8d35c531c458d3e480e9f3191847d062ec5ccff7bc51e949d5f2c3540c189a4eca1e8633a6"
+             "2cf2d0923101c27e38013e71de9ae91a704849bff7fbe2ce5bf4bd666fd9731102a53193fe5a9a5a50644"
+             "ff8b1183fa897646598caad22a37f9544510836372b44c58c98586fb7144629cd8c9479592d996d32ff6d"
+             "395c0b8442ec5aa1ef8051529ea0e375883cefc72c04e360b4ef8f5760650589ca814918f678eee39b884"
+             "d5af8136a9630a6cc0cde157dc8e00f39540628d5f335b2c36c54c7c8bc3738a6b21acff815405afa28e5"
+             "183f550dac19abcf1145a7f9ced987db680e4a229cac75dee347ec9ebce1fc3dbbbb0203010001";
+
+  auto pub_key = Utility::importPublicKey(Hex::decode(key));
+  EXPECT_NE(nullptr, pub_key.get());
+
+  key = "badkey";
+
+  pub_key = Utility::importPublicKey(Hex::decode(key));
+  EXPECT_EQ(nullptr, pub_key.get());
+}
+
+TEST(UtilityTest, TestVerifySignature) {
+  auto key = "30820122300d06092a864886f70d01010105000382010f003082010a0282010100a7471266d01d160308d"
+             "73409c06f2e8d35c531c458d3e480e9f3191847d062ec5ccff7bc51e949d5f2c3540c189a4eca1e8633a6"
+             "2cf2d0923101c27e38013e71de9ae91a704849bff7fbe2ce5bf4bd666fd9731102a53193fe5a9a5a50644"
+             "ff8b1183fa897646598caad22a37f9544510836372b44c58c98586fb7144629cd8c9479592d996d32ff6d"
+             "395c0b8442ec5aa1ef8051529ea0e375883cefc72c04e360b4ef8f5760650589ca814918f678eee39b884"
+             "d5af8136a9630a6cc0cde157dc8e00f39540628d5f335b2c36c54c7c8bc3738a6b21acff815405afa28e5"
+             "183f550dac19abcf1145a7f9ced987db680e4a229cac75dee347ec9ebce1fc3dbbbb0203010001";
+  auto hash_func = "sha256";
+  auto signature =
+      "345ac3a167558f4f387a81c2d64234d901a7ceaa544db779d2f797b0ea4ef851b740905a63e2f4d5af42cee093a2"
+      "9c7155db9a63d3d483e0ef948f5ac51ce4e10a3a6606fd93ef68ee47b30c37491103039459122f78e1c7ea71a1a5"
+      "ea24bb6519bca02c8c9915fe8be24927c91812a13db72dbcb500103a79e8f67ff8cb9e2a631974e0668ab3977bf5"
+      "70a91b67d1b6bcd5dce84055f21427d64f4256a042ab1dc8e925d53a769f6681a873f5859693a7728fcbe95beace"
+      "1563b5ffbcd7c93b898aeba31421dafbfadeea50229c49fd6c445449314460f3d19150bd29a91333beaced557ed6"
+      "295234f7c14fa46303b7e977d2c89ba8a39a46a35f33eb07a332";
+  auto data = "hello";
+
+  auto pub_key = Utility::importPublicKey(Hex::decode(key));
+
+  std::vector<uint8_t> text(data, data + strlen(data));
+
+  auto sig = Hex::decode(signature);
+  auto result = Utility::verifySignature(hash_func, pub_key.get(), sig, text);
+
+  EXPECT_EQ(true, result.result_);
+  EXPECT_EQ("", result.error_message_);
+
+  result = Utility::verifySignature("unknown", pub_key.get(), sig, text);
+  EXPECT_EQ(false, result.result_);
+  EXPECT_EQ("unknown is not supported.", result.error_message_);
+
+  result = Utility::verifySignature(hash_func, nullptr, sig, text);
+  EXPECT_EQ(false, result.result_);
+  EXPECT_EQ("Failed to initialize digest verify.", result.error_message_);
+
+  data = "baddata";
+  text = std::vector<uint8_t>(data, data + strlen(data));
+  result = Utility::verifySignature(hash_func, pub_key.get(), sig, text);
+  EXPECT_EQ(false, result.result_);
+  EXPECT_EQ("Failed to verify digest. Error code: 0", result.error_message_);
+
+  data = "hello";
+  text = std::vector<uint8_t>(data, data + strlen(data));
+  result = Utility::verifySignature(hash_func, pub_key.get(), Hex::decode("000000"), text);
+  EXPECT_EQ(false, result.result_);
+  EXPECT_EQ("Failed to verify digest. Error code: 0", result.error_message_);
+}
+
 } // namespace
 } // namespace Crypto
 } // namespace Common

--- a/test/common/http/http1/conn_pool_test.cc
+++ b/test/common/http/http1/conn_pool_test.cc
@@ -74,7 +74,7 @@ public:
   MOCK_METHOD0(createCodecClient_, CodecClient*());
   MOCK_METHOD0(onClientDestroy, void());
 
-  void expectClientCreate() {
+  void expectClientCreate(Protocol protocol = Protocol::Http11) {
     test_clients_.emplace_back();
     TestCodecClient& test_client = test_clients_.back();
     test_client.connection_ = new NiceMock<Network::MockClientConnection>();
@@ -99,6 +99,7 @@ public:
         .WillOnce(Return(test_client.connection_));
     EXPECT_CALL(*this, createCodecClient_()).WillOnce(Return(test_client.codec_client_));
     EXPECT_CALL(*test_client.connect_timer_, enableTimer(_));
+    ON_CALL(*test_client.codec_, protocol()).WillByDefault(Return(protocol));
   }
 
   void expectEnableUpstreamReady() {
@@ -475,7 +476,9 @@ TEST_F(Http1ConnPoolImplTest, MaxConnections) {
 
   conn_pool_.expectAndRunUpstreamReady();
   callbacks2.outer_encoder_->encodeHeaders(TestHeaderMapImpl{}, true);
-  response_headers.reset(new TestHeaderMapImpl{{":status", "200"}});
+  // N.B. clang_tidy insists that we use std::make_unique which can not infer std::initialize_list.
+  response_headers = std::make_unique<TestHeaderMapImpl>(
+      std::initializer_list<std::pair<std::string, std::string>>{{":status", "200"}});
   inner_decoder->decodeHeaders(std::move(response_headers), true);
 
   // Cause the connection to go away.
@@ -537,7 +540,9 @@ TEST_F(Http1ConnPoolImplTest, ConnectionCloseWithoutHeader) {
   conn_pool_.test_clients_[0].connection_->raiseEvent(Network::ConnectionEvent::Connected);
 
   callbacks2.outer_encoder_->encodeHeaders(TestHeaderMapImpl{}, true);
-  response_headers.reset(new TestHeaderMapImpl{{":status", "200"}});
+  // N.B. clang_tidy insists that we use std::make_unique which can not infer std::initialize_list.
+  response_headers = std::make_unique<TestHeaderMapImpl>(
+      std::initializer_list<std::pair<std::string, std::string>>{{":status", "200"}});
   inner_decoder->decodeHeaders(std::move(response_headers), true);
 
   EXPECT_CALL(conn_pool_, onClientDestroy());
@@ -605,6 +610,39 @@ TEST_F(Http1ConnPoolImplTest, ProxyConnectionCloseHeader) {
   EXPECT_CALL(conn_pool_, onClientDestroy());
   Http::HeaderMapPtr response_headers(
       new TestHeaderMapImpl{{":status", "200"}, {"Proxy-Connection", "Close"}});
+  inner_decoder->decodeHeaders(std::move(response_headers), true);
+  dispatcher_.clearDeferredDeleteList();
+
+  EXPECT_EQ(0U, cluster_->stats_.upstream_cx_destroy_with_active_rq_.value());
+}
+
+/**
+ * Test when upstream is HTTP/1.0 and does not send 'connection: keep-alive'
+ */
+TEST_F(Http1ConnPoolImplTest, Http10NoConnectionKeepAlive) {
+  InSequence s;
+
+  // Request 1 should kick off a new connection.
+  NiceMock<Http::MockStreamDecoder> outer_decoder;
+  ConnPoolCallbacks callbacks;
+  conn_pool_.expectClientCreate(Protocol::Http10);
+  Http::ConnectionPool::Cancellable* handle = conn_pool_.newStream(outer_decoder, callbacks);
+
+  EXPECT_NE(nullptr, handle);
+
+  NiceMock<Http::MockStreamEncoder> request_encoder;
+  Http::StreamDecoder* inner_decoder;
+  EXPECT_CALL(*conn_pool_.test_clients_[0].codec_, newStream(_))
+      .WillOnce(DoAll(SaveArgAddress(&inner_decoder), ReturnRef(request_encoder)));
+  EXPECT_CALL(callbacks.pool_ready_, ready());
+
+  conn_pool_.test_clients_[0].connection_->raiseEvent(Network::ConnectionEvent::Connected);
+  callbacks.outer_encoder_->encodeHeaders(TestHeaderMapImpl{}, true);
+
+  // Response without 'connection: keep-alive' which should cause the connection to go away.
+  EXPECT_CALL(conn_pool_, onClientDestroy());
+  Http::HeaderMapPtr response_headers(
+      new TestHeaderMapImpl{{":protocol", "HTTP/1.0"}, {":status", "200"}});
   inner_decoder->decodeHeaders(std::move(response_headers), true);
   dispatcher_.clearDeferredDeleteList();
 

--- a/test/extensions/filters/http/lua/lua_filter_test.cc
+++ b/test/extensions/filters/http/lua/lua_filter_test.cc
@@ -1577,6 +1577,131 @@ TEST_F(LuaHttpFilterTest, CheckConnection) {
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, true));
 }
 
+TEST_F(LuaHttpFilterTest, ImportPublicKey) {
+  const std::string SCRIPT{R"EOF(
+    function string.fromhex(str)
+      return (str:gsub('..', function (cc)
+        return string.char(tonumber(cc, 16))
+      end))
+    end
+    function envoy_on_request(request_handle)
+      key = "30820122300d06092a864886f70d01010105000382010f003082010a0282010100a7471266d01d160308d73409c06f2e8d35c531c458d3e480e9f3191847d062ec5ccff7bc51e949d5f2c3540c189a4eca1e8633a62cf2d0923101c27e38013e71de9ae91a704849bff7fbe2ce5bf4bd666fd9731102a53193fe5a9a5a50644ff8b1183fa897646598caad22a37f9544510836372b44c58c98586fb7144629cd8c9479592d996d32ff6d395c0b8442ec5aa1ef8051529ea0e375883cefc72c04e360b4ef8f5760650589ca814918f678eee39b884d5af8136a9630a6cc0cde157dc8e00f39540628d5f335b2c36c54c7c8bc3738a6b21acff815405afa28e5183f550dac19abcf1145a7f9ced987db680e4a229cac75dee347ec9ebce1fc3dbbbb0203010001"
+      raw = key:fromhex()
+      key = request_handle:importPublicKey(raw, string.len(raw)):get()
+
+      if key == nil then
+        request_handle:logTrace("failed to import public key")
+      else
+        request_handle:logTrace("succeeded to import public key")
+      end
+    end
+  )EOF"};
+
+  InSequence s;
+  setup(SCRIPT);
+
+  Http::TestHeaderMapImpl request_headers{{":path", "/"}};
+
+  EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("succeeded to import public key")));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, true));
+}
+
+TEST_F(LuaHttpFilterTest, InvalidPublicKey) {
+  const std::string SCRIPT{R"EOF(
+    function string.fromhex(str)
+      return (str:gsub('..', function (cc)
+        return string.char(tonumber(cc, 16))
+      end))
+    end
+    function envoy_on_request(request_handle)
+      key = "0000"
+      raw = key:fromhex()
+      key = request_handle:importPublicKey(raw, string.len(raw)):get()
+
+      if key == nil then
+        request_handle:logTrace("failed to import public key")
+      else
+        request_handle:logTrace("succeeded to import public key")
+      end
+    end
+  )EOF"};
+
+  InSequence s;
+  setup(SCRIPT);
+
+  Http::TestHeaderMapImpl request_headers{{":path", "/"}};
+
+  EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("failed to import public key")));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, true));
+}
+
+TEST_F(LuaHttpFilterTest, SignatureVerify) {
+  const std::string SCRIPT{R"EOF(
+    function string.fromhex(str)
+      return (str:gsub('..', function (cc)
+        return string.char(tonumber(cc, 16))
+      end))
+    end
+    function envoy_on_request(request_handle)
+      key = "30820122300d06092a864886f70d01010105000382010f003082010a0282010100a7471266d01d160308d73409c06f2e8d35c531c458d3e480e9f3191847d062ec5ccff7bc51e949d5f2c3540c189a4eca1e8633a62cf2d0923101c27e38013e71de9ae91a704849bff7fbe2ce5bf4bd666fd9731102a53193fe5a9a5a50644ff8b1183fa897646598caad22a37f9544510836372b44c58c98586fb7144629cd8c9479592d996d32ff6d395c0b8442ec5aa1ef8051529ea0e375883cefc72c04e360b4ef8f5760650589ca814918f678eee39b884d5af8136a9630a6cc0cde157dc8e00f39540628d5f335b2c36c54c7c8bc3738a6b21acff815405afa28e5183f550dac19abcf1145a7f9ced987db680e4a229cac75dee347ec9ebce1fc3dbbbb0203010001"
+      hashFunc = "sha256"
+      signature = "345ac3a167558f4f387a81c2d64234d901a7ceaa544db779d2f797b0ea4ef851b740905a63e2f4d5af42cee093a29c7155db9a63d3d483e0ef948f5ac51ce4e10a3a6606fd93ef68ee47b30c37491103039459122f78e1c7ea71a1a5ea24bb6519bca02c8c9915fe8be24927c91812a13db72dbcb500103a79e8f67ff8cb9e2a631974e0668ab3977bf570a91b67d1b6bcd5dce84055f21427d64f4256a042ab1dc8e925d53a769f6681a873f5859693a7728fcbe95beace1563b5ffbcd7c93b898aeba31421dafbfadeea50229c49fd6c445449314460f3d19150bd29a91333beaced557ed6295234f7c14fa46303b7e977d2c89ba8a39a46a35f33eb07a332"
+      data = "hello"
+
+      rawkey = key:fromhex()
+      pubkey = request_handle:importPublicKey(rawkey, string.len(rawkey)):get()
+
+      if pubkey == nil then
+        request_handle:logTrace("failed to import public key")
+        return
+      end
+
+      rawsig = signature:fromhex()
+
+      ok, error = request_handle:verifySignature(hashFunc, pubkey, rawsig, string.len(rawsig), data, string.len(data)) 
+      if ok then
+        request_handle:logTrace("signature is valid")
+      else
+        request_handle:logTrace(error)
+      end
+
+      ok, error = request_handle:verifySignature("unknown", pubkey, rawsig, string.len(rawsig), data, string.len(data)) 
+      if ok then
+        request_handle:logTrace("signature is valid")
+      else
+        request_handle:logTrace(error)
+      end
+
+      ok, error = request_handle:verifySignature(hashFunc, pubkey, "0000", 4, data, string.len(data)) 
+      if ok then
+        request_handle:logTrace("signature is valid")
+      else
+        request_handle:logTrace(error)
+      end
+
+      ok, error = request_handle:verifySignature(hashFunc, pubkey, rawsig, string.len(rawsig), "xxxx", 4) 
+      if ok then
+        request_handle:logTrace("signature is valid")
+      else
+        request_handle:logTrace(error)
+      end
+    end
+  )EOF"};
+
+  InSequence s;
+  setup(SCRIPT);
+
+  Http::TestHeaderMapImpl request_headers{{":path", "/"}};
+
+  EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("signature is valid")));
+  EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("unknown is not supported.")));
+  EXPECT_CALL(*filter_,
+              scriptLog(spdlog::level::trace, StrEq("Failed to verify digest. Error code: 0")));
+  EXPECT_CALL(*filter_,
+              scriptLog(spdlog::level::trace, StrEq("Failed to verify digest. Error code: 0")));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, true));
+}
+
 } // namespace
 } // namespace Lua
 } // namespace HttpFilters

--- a/test/extensions/filters/http/lua/lua_integration_test.cc
+++ b/test/extensions/filters/http/lua/lua_integration_test.cc
@@ -53,6 +53,8 @@ public:
             foo.bar:
               foo: bar
               baz: bat
+            keyset:
+              foo: MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAp0cSZtAdFgMI1zQJwG8ujTXFMcRY0+SA6fMZGEfQYuxcz/e8UelJ1fLDVAwYmk7KHoYzpizy0JIxAcJ+OAE+cd6a6RpwSEm/9/vizlv0vWZv2XMRAqUxk/5amlpQZE/4sRg/qJdkZZjKrSKjf5VEUQg2NytExYyYWG+3FEYpzYyUeVktmW0y/205XAuEQuxaoe+AUVKeoON1iDzvxywE42C0749XYGUFicqBSRj2eO7jm4hNWvgTapYwpswM3hV9yOAPOVQGKNXzNbLDbFTHyLw3OKayGs/4FUBa+ijlGD9VDawZq88RRaf5ztmH22gOSiKcrHXe40fsnrzh/D27uwIDAQAB
           )EOF";
 
           ProtobufWkt::Struct value;
@@ -383,6 +385,99 @@ config:
     EXPECT_TRUE(response->complete());
     EXPECT_EQ("200", response->headers().Status()->value().getStringView());
   }
+
+  cleanup();
+}
+
+// Basic test for verifying signature.
+TEST_P(LuaIntegrationTest, SignatureVerification) {
+  const std::string FILTER_AND_CODE =
+      R"EOF(
+name: envoy.lua
+config:
+  inline_code: |
+    function string.fromhex(str)
+      return (str:gsub('..', function (cc)
+        return string.char(tonumber(cc, 16))
+      end))
+    end
+
+    -- decoding
+    function dec(data)
+      local b='ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
+      data = string.gsub(data, '[^'..b..'=]', '')
+      return (data:gsub('.', function(x)
+        if (x == '=') then return '' end
+        local r,f='',(b:find(x)-1)
+        for i=6,1,-1 do r=r..(f%2^i-f%2^(i-1)>0 and '1' or '0') end
+        return r;
+      end):gsub('%d%d%d?%d?%d?%d?%d?%d?', function(x)
+        if (#x ~= 8) then return '' end
+        local c=0
+        for i=1,8 do c=c+(x:sub(i,i)=='1' and 2^(8-i) or 0) end
+        return string.char(c)
+      end))
+    end
+
+    function envoy_on_request(request_handle)
+      local metadata = request_handle:metadata():get("keyset")
+      local keyder = metadata[request_handle:headers():get("keyid")]
+
+      local rawkeyder = dec(keyder)
+      local pubkey = request_handle:importPublicKey(rawkeyder, string.len(rawkeyder)):get()
+
+      if pubkey == nil then
+        request_handle:logErr("log test")
+        request_handle:headers():add("signature_verification", "rejected")
+        return
+      end
+
+      local hash = request_handle:headers():get("hash")
+      local sig = request_handle:headers():get("signature")
+      local rawsig = sig:fromhex()
+      local data = request_handle:headers():get("message")
+      local ok, error = request_handle:verifySignature(hash, pubkey, rawsig, string.len(rawsig), data, string.len(data)) 
+
+      if ok then
+        request_handle:headers():add("signature_verification", "approved")
+      else
+        request_handle:logErr(error)
+        request_handle:headers():add("signature_verification", "rejected")
+      end
+
+      request_handle:releasePublicKey(pubkey)
+    end
+)EOF";
+
+  initializeFilter(FILTER_AND_CODE);
+
+  auto signature =
+      "345ac3a167558f4f387a81c2d64234d901a7ceaa544db779d2f797b0ea4ef851b740905a63e2f4d5af42cee093a2"
+      "9c7155db9a63d3d483e0ef948f5ac51ce4e10a3a6606fd93ef68ee47b30c37491103039459122f78e1c7ea71a1a5"
+      "ea24bb6519bca02c8c9915fe8be24927c91812a13db72dbcb500103a79e8f67ff8cb9e2a631974e0668ab3977bf5"
+      "70a91b67d1b6bcd5dce84055f21427d64f4256a042ab1dc8e925d53a769f6681a873f5859693a7728fcbe95beace"
+      "1563b5ffbcd7c93b898aeba31421dafbfadeea50229c49fd6c445449314460f3d19150bd29a91333beaced557ed6"
+      "295234f7c14fa46303b7e977d2c89ba8a39a46a35f33eb07a332";
+
+  codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
+  Http::TestHeaderMapImpl request_headers{
+      {":method", "POST"},    {":path", "/test/long/url"},     {":scheme", "https"},
+      {":authority", "host"}, {"x-forwarded-for", "10.0.0.1"}, {"message", "hello"},
+      {"keyid", "foo"},       {"signature", signature},        {"hash", "sha256"}};
+
+  auto response = codec_client_->makeHeaderOnlyRequest(request_headers);
+  waitForNextUpstreamRequest();
+
+  EXPECT_EQ("approved", upstream_request_->headers()
+                            .get(Http::LowerCaseString("signature_verification"))
+                            ->value()
+                            .getStringView());
+
+  upstream_request_->encodeHeaders(default_response_headers_, true);
+  response->waitForEndStream();
+
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
 
   cleanup();
 }


### PR DESCRIPTION
Signed-off-by: Yuchen Dai <silentdai@gmail.com>

For istio scenario we want hierarchical listener search in below order, 
https://github.com/envoyproxy/envoy/blob/master/source/server/connection_handler_impl.cc#L204

1. match inbound listener first
2. If none of the inbound listener is matched and the destination ip is pod ip, match listener named "ISTIO_WILDCARD_PORT_LISTENER" if any
3. match the outbound listener

This PR is extremely safe: if there is no such magical listener, the logic falls back. 

To verify we can add a static listener named "ISTIO_WILDCARD_PORT_LISTENER" in bootstrap