### PR TITLE
envoy attempt to match istio wildcard port listener

### DIFF
--- a/source/common/network/utility.h
+++ b/source/common/network/utility.h
@@ -140,6 +140,12 @@ public:
   static bool isLocalConnection(const Network::ConnectionSocket& socket);
 
   /**
+   * Determine whether this is a local address.
+   * @return bool the address is a local address.
+   */
+  static bool isLocalIpAddress(const Address::Instance& address);
+
+  /**
    * Determine whether this is an internal (RFC1918) address.
    * @return bool the address is an RFC1918 address.
    */


### PR DESCRIPTION
Signed-off-by: Yuchen Dai <silentdai@gmail.com>

For istio scenario we want hierarchical listener search in below order,
https://github.com/envoyproxy/envoy/blob/master/source/server/connection_handler_impl.cc#L204

1. match inbound listener first
2. If none of the inbound listener is matched and the destination ip is pod ip, match listener named "ISTIO_WILDCARD_PORT_LISTENER" if any
3. match the outbound listener
This PR is extremely safe: if there is no such magical listener, the logic falls back.

To verify we can add a static listener named "ISTIO_WILDCARD_PORT_LISTENER" in bootstrap


