### PR TITLE
Prototype: filter chain manager replaceable listener

### DIFF
--- a/include/envoy/network/filter.h
+++ b/include/envoy/network/filter.h
@@ -351,6 +351,8 @@ public:
   virtual const FilterChain* findFilterChain(const ConnectionSocket& socket) const PURE;
 };
 
+using FilterChainManagerSharedPtr = std::shared_ptr<FilterChainManager>;
+
 /**
  * Callbacks used by individual UDP listener read filter instances to communicate with the filter
  * manager.

--- a/include/envoy/network/listener.h
+++ b/include/envoy/network/listener.h
@@ -30,6 +30,12 @@ public:
   virtual FilterChainManager& filterChainManager() PURE;
 
   /**
+   * @return FilterChainManagerSharedPtr the factory for adding and searching through configured
+   *         filter chains.
+   */
+  virtual FilterChainManagerSharedPtr sharedFilterChainManager() PURE;
+
+  /**
    * @return FilterChainFactory& the factory for setting up the filter chain on a new
    *         connection.
    */

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -312,6 +312,12 @@ private:
 
     // Network::ListenerConfig
     Network::FilterChainManager& filterChainManager() override { return parent_; }
+    // TODO: replace this if the interface is agreed
+    Network::FilterChainManagerSharedPtr sharedFilterChainManager() override {
+      return Network::FilterChainManagerSharedPtr(&parent_,
+                                                  // A fake deleter
+                                                  [](auto) {});
+    }
     Network::FilterChainFactory& filterChainFactory() override { return parent_; }
     Network::Socket& socket() override { return parent_.mutable_socket(); }
     const Network::Socket& socket() const override { return parent_.mutable_socket(); }

--- a/source/server/listener_impl.cc
+++ b/source/server/listener_impl.cc
@@ -31,7 +31,7 @@ ListenerImpl::ListenerImpl(const envoy::api::v2::Listener& config, const std::st
                            bool workers_started, uint64_t hash,
                            ProtobufMessage::ValidationVisitor& validation_visitor)
     : parent_(parent), address_(Network::Address::resolveProtoAddress(config.address())),
-      filter_chain_manager_(address_),
+      filter_chain_manager_(std::make_shared<FilterChainManagerImpl>(address_)),
       socket_type_(Network::Utility::protobufAddressSocketType(config.address())),
       global_scope_(parent_.server_.stats().createScope("")),
       listener_scope_(
@@ -123,7 +123,7 @@ ListenerImpl::ListenerImpl(const envoy::api::v2::Listener& config, const std::st
       parent_.server_.threadLocal(), validation_visitor, parent_.server_.api());
   factory_context.setInitManager(initManager());
   ListenerFilterChainFactoryBuilder builder(*this, factory_context);
-  filter_chain_manager_.addFilterChain(config.filter_chains(), builder);
+  filter_chain_manager_->addFilterChain(config.filter_chains(), builder);
 
   if (socket_type_ == Network::Address::SocketType::Datagram) {
     return;

--- a/source/server/listener_impl.h
+++ b/source/server/listener_impl.h
@@ -78,7 +78,10 @@ public:
   const std::string& versionInfo() { return version_info_; }
 
   // Network::ListenerConfig
-  Network::FilterChainManager& filterChainManager() override { return filter_chain_manager_; }
+  Network::FilterChainManager& filterChainManager() override { return *filter_chain_manager_; }
+  Network::FilterChainManagerSharedPtr sharedFilterChainManager() override {
+    return filter_chain_manager_;
+  }
   Network::FilterChainFactory& filterChainFactory() override { return *this; }
   Network::Socket& socket() override { return *socket_; }
   const Network::Socket& socket() const override { return *socket_; }
@@ -160,7 +163,7 @@ private:
 
   ListenerManagerImpl& parent_;
   Network::Address::InstanceConstSharedPtr address_;
-  FilterChainManagerImpl filter_chain_manager_;
+  std::shared_ptr<FilterChainManagerImpl> filter_chain_manager_;
 
   Network::Address::SocketType socket_type_;
   Network::SocketSharedPtr socket_;


### PR DESCRIPTION
A WIP prototype to resolve the pain of connection drain during frequent network network filter chain update.
My answer is not to drain listener.

This PR is exploring what are the necessary changes to support such listener.

Full design https://docs.google.com/document/d/1fjud3xSNRxxEwAWR1COsDnViB4FtTKTFgfQVW0IPU0c/edit#

[ ] add interface at ActiveTcpListener: no existing functionality is broken (add listener, stop listener, remove listener)
[ ] worker thread: serving user request during filter chains update: no memleak, no broken connection
[ ] main thread: respond LDS update: add/update listener, warm up and execute update by the above ActiveTcpListener update


Signed-off-by: Yuchen Dai <silentdai@gmail.com>

