### PR TITLE
experimental lsan build

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -52,8 +52,12 @@ build:asan --config=sanitizer
 # ASAN install its signal handler, disable ours so the stacktrace will be printed by ASAN
 build:asan --define signal_trace=disabled
 build:asan --define ENVOY_CONFIG_ASAN=1
-build:asan --copt -fsanitize=address,undefined
-build:asan --linkopt -fsanitize=address,undefined
+build:asan --copt -fsanitize=leak
+no-omit-frame-pointer
+build:asan --linkopt -fsanitize=leak
+build:asan --copt=-fno-omit-frame-pointer
+#build:asan --copt -fsanitize=address,undefined
+#build:asan --linkopt -fsanitize=address,undefined
 # vptr and function sanitizer are enabled in clang-asan if it is set up via bazel/setup_clang.sh.
 build:asan --copt -fno-sanitize=vptr,function
 build:asan --linkopt -fno-sanitize=vptr,function
@@ -116,6 +120,7 @@ build:libc++ --action_env=BAZEL_CXXOPTS=-stdlib=libc++
 build:libc++ --action_env=BAZEL_LINKLIBS=-l%:libc++.a:-l%:libc++abi.a
 build:libc++ --action_env=BAZEL_LINKOPTS=-lm:-pthread
 build:libc++ --define force_libcpp=enabled
+#lambdai build:libc++ --copt -fsanitize=leak
 
 # Optimize build for binary size reduction.
 build:sizeopt -c opt --copt -Os

--- a/.bazelrc
+++ b/.bazelrc
@@ -53,7 +53,6 @@ build:asan --config=sanitizer
 build:asan --define signal_trace=disabled
 build:asan --define ENVOY_CONFIG_ASAN=1
 build:asan --copt -fsanitize=leak
-no-omit-frame-pointer
 build:asan --linkopt -fsanitize=leak
 build:asan --copt=-fno-omit-frame-pointer
 #build:asan --copt -fsanitize=address,undefined
@@ -61,6 +60,7 @@ build:asan --copt=-fno-omit-frame-pointer
 # vptr and function sanitizer are enabled in clang-asan if it is set up via bazel/setup_clang.sh.
 build:asan --copt -fno-sanitize=vptr,function
 build:asan --linkopt -fno-sanitize=vptr,function
+build:asan --linkopt -fno-omit-frame-pointer
 build:asan --copt -DADDRESS_SANITIZER=1
 build:asan --copt -D__SANITIZE_ADDRESS__
 build:asan --test_env=ASAN_OPTIONS=handle_abort=1:allow_addr2line=true:check_initialization_order=true:strict_init_order=true:detect_odr_violation=1

--- a/source/exe/main.cc
+++ b/source/exe/main.cc
@@ -1,5 +1,6 @@
+#include "common/common/macros.h"
 #include "exe/main_common.h"
-
+#include <iostream>
 // NOLINT(namespace-envoy)
 
 /**
@@ -9,4 +10,14 @@
  * deployment such as initializing signal handling. It calls main_common
  * after setting up command line options.
  */
-int main(int argc, char** argv) { return Envoy::MainCommon::main(argc, argv); }
+int main(int argc, char** argv) {
+  auto pnew = new (int)(7);
+  pnew = nullptr; // The memory is leaked here.
+  auto pmalloc = malloc(7);
+  pmalloc = nullptr; // The memory is leaked here.
+  std::cout << "foo: after malloc and new" << std::endl;
+  return Envoy::MainCommon::main(argc, argv);
+  // UNREFERENCED_PARAMETER(argc);
+  // UNREFERENCED_PARAMETER(argv);
+  // return 0;
+}


### PR DESCRIPTION
Signed-off-by: Yuchen Dai <silentdai@gmail.com>
```
lambdai@devserverssd:~/workspace/envoy (lsan)$ export PATH=/usr/lib/llvm-9/bin:$PATH
lambdai@devserverssd:~/workspace/envoy (lsan)$ bazel-bin/source/exe/envoy-static  ==3488==AddressSanitizer CHECK failed: /tmp/final/llvm.src/projects/compiler-rt/lib/asan/asan_poisoning.cc:388 "((*(u8*)MemToShadow(a))) == ((0))" (0xfc, 0x0)
    #0 0x55faf6e94e1e in __asan::AsanCheckFailed(char const*, int, char const*, unsigned long long, unsigned long long) (/home/lambdai/bazelcache/execroot/envoy/bazel-out/k8-fastbuild/bin/source/exe/envoy-static+0xf9b8e1e)
    #1 0x55faf6ea944f in __sanitizer::CheckFailed(char const*, int, char const*, unsigned long long, unsigned long long) (/home/lambdai/bazelcache/execroot/envoy/bazel-out/k8-fastbuild/bin/source/exe/envoy-static+0xf9cd44f)
    #2 0x55faf6e90335 in __sanitizer_annotate_contiguous_container (/home/lambdai/bazelcache/execroot/envoy/bazel-out/k8-fastbuild/bin/source/exe/envoy-static+0xf9b4335)
    #3 0x55fafdb852a0 in std::__1::vector<int, std::__1::allocator<int> >::pop_back() (/home/lambdai/bazelcache/execroot/envoy/bazel-out/k8-fastbuild/bin/source/exe/envoy-static+0x166a92a0)
    #4 0x55fb00419aa4 in re2::Prog::MarkSuccessors(re2::SparseArray<int>*, re2::SparseArray<int>*, std::__1::vector<std::__1::vector<int, std::__1::allocator<int> >, std::__1::allocator<std::__1::vector<int, std::__1::allocator<int> > > >*, re2::SparseSetT<void>*, std::__1::vector<int, std::__1::allocator<int> >*) (/home/lambdai/bazelcache/execroot/envoy/bazel-out/k8-fastbuild/bin/source/exe/envoy-static+0x18f3daa4)
    #5 0x55fb004193db in re2::Prog::Flatten() (/home/lambdai/bazelcache/execroot/envoy/bazel-out/k8-fastbuild/bin/source/exe/envoy-static+0x18f3d3db)
    #6 0x55fb0043884b in re2::Compiler::Finish(re2::Regexp*) (/home/lambdai/bazelcache/execroot/envoy/bazel-out/k8-fastbuild/bin/source/exe/envoy-static+0x18f5c84b)
    #7 0x55fb00437f6f in re2::Compiler::Compile(re2::Regexp*, bool, long) (/home/lambdai/bazelcache/execroot/envoy/bazel-out/k8-fastbuild/bin/source/exe/envoy-static+0x18f5bf6f)
    #8 0x55fb00438e8d in re2::Regexp::CompileToProg(long) (/home/lambdai/bazelcache/execroot/envoy/bazel-out/k8-fastbuild/bin/source/exe/envoy-static+0x18f5ce8d)
    #9 0x55fb00410b01 in re2::RE2::Init(re2::StringPiece const&, re2::RE2::Options const&) (/home/lambdai/bazelcache/execroot/envoy/bazel-out/k8-fastbuild/bin/source/exe/envoy-static+0x18f34b01)
    #10 0x55fb0041083b in re2::RE2::RE2(char const*) (/home/lambdai/bazelcache/execroot/envoy/bazel-out/k8-fastbuild/bin/source/exe/envoy-static+0x18f3483b)
    #11 0x55faf6f65e7b in __cxx_global_var_init (/home/lambdai/bazelcache/execroot/envoy/bazel-out/k8-fastbuild/bin/source/exe/envoy-static+0xfa89e7b)
    #12 0x55faf6f65f38 in _GLOBAL__sub_I_file.pb.validate.cc (/home/lambdai/bazelcache/execroot/envoy/bazel-out/k8-fastbuild/bin/source/exe/envoy-static+0xfa89f38)
    #13 0x55fb004f94fc in __libc_csu_init (/home/lambdai/bazelcache/execroot/envoy/bazel-out/k8-fastbuild/bin/source/exe/envoy-static+0x1901d4fc)
    #14 0x7f4341fbfb27 in __libc_start_main /build/glibc-2ORdQG/glibc-2.27/csu/../csu/libc-start.c:266
    #15 0x55faf6e15029 in _start (/home/lambdai/bazelcache/execroot/envoy/bazel-out/k8-fastbuild/bin/source/exe/envoy-static+0xf939029)
```